### PR TITLE
Selvennetty ohjeita asentamiseen ja ajamiseen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 /siirtoaanivaali2022/__pycache__
 /vaalit/
+/dist/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,33 @@ Ohjelma käynnistetään suorittamalla tiedosto app.py. Ohjelma kysyy käyttäj�
 
 Ohjelma tulostaa laskentadataa kahteen tekstitiedostoon. Tiedosto, jonka nimi päättyy 'laskenta', sisältää tarkempaa dataa laskennan etenemisestä. Tiedosto, jonka nimi päättyy 'tulokset', sisältää laskennan tulokset lyhyemmässä muodossa, joka on helpompi esitellä esimerkiksi kokokseen osallitujille. Mikäli ääntenlaskun aikana tarvitsee ratkoa tasatilanteita pudotusvaiheessa, tiedostoja tulee useampi pari reskursiivisesti. Ensimmäisestä tiedostoparista löytyy ääntenlaskun lopullinen tulos.
 
+## Ohjelman asentaminen
+
+Kloonaa repositorio omalle koneellesi haluamaasi kansioon. 
+
+Linuxilla esimerkiksi `~/Downloads`-kansioon asentaminen:
+
+- Avaa komentorivi
+- `cd ~/Downloads`
+- `git clone https://github.com/mkkarl/Siirtoaanivaali2022.git`
+- `cd Siirtoaanivaali2022`
+- `mkdir vaalit`
+
+OpaVotesta pitäisi saada jokaisesta vaalista tekstitiedoston ladattavaksi. 
+Tallenna ne repositorion sisälle.
+
+## Ohjelman ajaminen
+
+Oletuksena, että ohjelma on asennettu `~/Downloads`-kansioon.
+
+- Avaa komentorivi
+- `cd ~/Downloads/Siirtoaanivaali2022`
+- `python siirtoaanivaali2022/app.py`
+
+Ohjelma pyytää lipukedatan tiedostonimeä. 
+Kirjoita OpaVotesta lataamasi tiedoston nimi ja paina enteriä.
+Ohjelma tekee kaksi tiedostoa `vaalit`-kansioon kutakin vaalia kohden.
+
 ## Havaitut ongelmat vaalijärjestyksessä
 
 Valijärjestyksessä on havaittu joitain ongelmia. Niistä on kerrottu enemmän [täällä](dokumentaatio/havaitut_ongelmat.md).


### PR DESCRIPTION
Kirjoitin README.md-tiedostoon tarkemmin asennusohjeita. Lisäksi lisäsin dist-kansion .gitignoreen (poetry generoi sennimisen kansion komennolla `poetry build`)